### PR TITLE
Update portable contacts specification URL

### DIFF
--- a/resources/types/user.edn
+++ b/resources/types/user.edn
@@ -1,7 +1,7 @@
 {:id :user
  :name "User"
  :description "The user object is based on the [portable contacts
-specification](http://portablecontacts.net/draft-spec.html). It is extended with
+specification](https://tools.ietf.org/html/draft-smarr-vcarddav-portable-contacts-00). It is extended with
 some custom fields. `userId` is an integer and represents the unique user ID.
 `id` is a legacy uuid and should be ignored in new integrations. The `email` and
 `phoneNumber` fields will always contain the primary used for both if available.
@@ -25,7 +25,7 @@ public profile data will be available:
 * `locale`
 * `tracking`
 "
- :fields [{:name "id"                  :type :string         :description "Legacy `uuid`. Don't use. [Portable contacts](http://portablecontacts.net/draft-spec.html#anchor16)" :always-available? true}
+ :fields [{:name "id"                  :type :string         :description "Legacy `uuid`. Don't use. [Portable contacts](https://tools.ietf.org/html/draft-smarr-vcarddav-portable-contacts-00#section-7.2.1)" :always-available? true}
           {:name "userId"              :type :integer-string :description "Unique user ID. Custom extension." :always-available? true}
           {:name "name"                :type :name           :description "A JSON string. See [the name type](/types/name/) for details" :always-available? true}
           {:name "displayName"         :type :string         :description "Name suitable for displaying to end-users." :always-available? true}
@@ -42,8 +42,8 @@ public profile data will be available:
           {:name "url"                 :type :string}
           {:name "photo"               :type :string         :description "URL to a photo of the user (GIF/JPG/PNG)"}
           {:name "preferredUsername"   :type :string}
-          {:name "gender"              :type :string         :description "One of undisclosed, female, male, other, withheld. Default is undisclosed. [Portable contacts](http://portablecontacts.net/draft-spec.html#anchor16)" :always-available? true}
-          {:name "birthday"            :type :date           :description "Date of birth in YYYY-MM-DD format. Year will be 0000 if not provided. Defaults to 0000-00-00. [Portable contacts](http://portablecontacts.net/draft-spec.html#anchor16)" :always-available? true}
+          {:name "gender"              :type :string         :description "One of undisclosed, female, male, other, withheld. Default is undisclosed. [Portable contacts](https://tools.ietf.org/html/draft-smarr-vcarddav-portable-contacts-00#section-7.2.1)" :always-available? true}
+          {:name "birthday"            :type :date           :description "Date of birth in YYYY-MM-DD format. Year will be 0000 if not provided. Defaults to 0000-00-00. [Portable contacts](https://tools.ietf.org/html/draft-smarr-vcarddav-portable-contacts-00#section-7.2.1)" :always-available? true}
           {:name "locale"              :type :string         :description "The user's preferred locale. Locales follow ISO Language and country codes respectively, joined by an underscore." :always-available? true}
           {:name "utcOffset"           :type :string         :description "The user's timezone, given as offset from UTC." :always-available? true}
           {:name "lastLoggedIn"        :type :datetime       :description "Returns false if the user has not been logged in before." :always-available? true}


### PR DESCRIPTION
Original site is no longer reachable: http://portablecontacts.net/draft-spec.html

There is IETF draft spec here: https://tools.ietf.org/html/draft-smarr-vcarddav-portable-contacts-00