### PR TITLE
Updated ‘base64 encoded’ to ‘base64 url encoded’

### DIFF
--- a/resources/endpoints/email-email-status-get.md
+++ b/resources/endpoints/email-email-status-get.md
@@ -1,7 +1,7 @@
 :introduction
 
 Get verification and availability status for an email address. Note that the
-email should be base64 encoded.
+email should be base64 url encoded.
 
 :example-params
 

--- a/resources/endpoints/phone-phone-status-get.md
+++ b/resources/endpoints/phone-phone-status-get.md
@@ -1,7 +1,7 @@
 :introduction
 
 Get verification and availability status for a phone number. Note that the
-phone number should be base64 encoded, following standard +46736151515.
+phone number should be base64 url encoded, following standard +46736151515.
 
 :example-params
 


### PR DESCRIPTION
For the endpoints /email/{email}/status and /phone/{phone}/status, it
said that the {email}/{phone} param should be base64 encoded, but in
fact it needs to be base64 url encoded.